### PR TITLE
Reverting back to http requests only for GUI communication with the d…

### DIFF
--- a/PythonFiles/Data/DBSender.py
+++ b/PythonFiles/Data/DBSender.py
@@ -21,11 +21,11 @@ class DBSender():
         return {"http": "http://127.0.0.1:8080"}
 
     def add_new_user_ID(self, user_ID, passwd):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/add_tester2.py'.format(self.db_url), data= {'person_name':user_ID, 'password': passwd}, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/add_tester2.py'.format(self.db_url), data= {'person_name':user_ID, 'password': passwd}, proxies=self.getProxies())
 
     # Returns an acceptable list of usernames from the database
     def get_usernames(self):
-        r = requests.get('http://cmslab3.umncmslab/~cros0400/{}/get_usernames.py'.format(self.db_url), proxies=self.getProxies())
+        r = requests.get('http://cmslab3.spa.umn.edu/~cros0400/{}/get_usernames.py'.format(self.db_url), proxies=self.getProxies())
         lines = r.text.split('\n')
 
         print(lines)
@@ -46,7 +46,7 @@ class DBSender():
     # Returns a list of booleans
     # Whether test (by index) has been completed or not
     def get_test_completion_staus(self, serial_number):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/get_test_completion_status.py'.format(self.db_url), data= serial_number, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/get_test_completion_status.py'.format(self.db_url), data= serial_number, proxies=self.getProxies())
         
         lines = r.text.split('\n')
         begin = lines.index("Begin") + 1 
@@ -66,7 +66,7 @@ class DBSender():
     # Returns a list of booleans
     # Whether or not DB has passing results 
     def get_previous_test_results(self, serial_number):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/get_previous_test_results.py'.format(self.db_url), data={'serial_number': str(serial_number)}, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/get_previous_test_results.py'.format(self.db_url), data={'serial_number': str(serial_number)}, proxies=self.getProxies())
         
         lines = r.text.split('\n')
 
@@ -89,13 +89,13 @@ class DBSender():
     # #TODO Verify if a board has already been instantiated with SN
     # Posts a new board with passed in serial number
     def add_new_board(self, sn):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/add_module2.py'.format(self.db_url), data={"serial_number": str(sn)}, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/add_module2.py'.format(self.db_url), data={"serial_number": str(sn)}, proxies=self.getProxies())
 
 
     def is_new_board(self, sn):
         
-        print('http://cmslab3.umncmslab/~cros0400/{}/is_new_board.py'.format(self.db_url))
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/is_new_board.py'.format(self.db_url), data={"serial_number": str(sn)}, proxies=self.getProxies())
+        print('http://cmslab3.spa.umn.edu/~cros0400/{}/is_new_board.py'.format(self.db_url))
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/is_new_board.py'.format(self.db_url), data={"serial_number": str(sn)}, proxies=self.getProxies())
         print(r.text)
         
         lines = r.text.split('\n')
@@ -119,13 +119,13 @@ class DBSender():
     # Posts information via the "info" dictionary
     # Serial number is within the info dictionary
     def add_board_info(self, info):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/add_board_info2.py'.format(self.db_url), data = info, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/add_board_info2.py'.format(self.db_url), data = info, proxies=self.getProxies())
     
     def add_initial_tests(self, results):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/add_init_test.py'.format(self.db_url), data = results, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/add_init_test.py'.format(self.db_url), data = results, proxies=self.getProxies())
         
     def add_general_test(self, results, files):
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/add_test2.py'.format(self.db_url), data = results, files=files, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/add_test2.py'.format(self.db_url), data = results, files=files, proxies=self.getProxies())
 
     def add_test_json(self, json_file, datafile_name):
         load_file = open(json_file)
@@ -136,12 +136,12 @@ class DBSender():
 
         attach_data = {'attach1': datafile}
         print("Read from json file:", results)
-        r = requests.post('http://cmslab3.umncmslab/~cros0400/{}/add_test_json.py'.format(self.db_url), data = results, files = attach_data, proxies=self.getProxies())
+        r = requests.post('http://cmslab3.spa.umn.edu/~cros0400/{}/add_test_json.py'.format(self.db_url), data = results, files = attach_data, proxies=self.getProxies())
 
 
  # Returns a list of all different types of tests
     def get_test_list(self):
-        r = requests.get('http://cmslab3.umncmslab/~cros0400/{}/get_test_types.py'.format(self.db_url), proxies=self.getProxies())
+        r = requests.get('http://cmslab3.spa.umn.edu/~cros0400/{}/get_test_types.py'.format(self.db_url), proxies=self.getProxies())
 
         lines = r.text.split('\n')
 

--- a/PythonFiles/Data/DataHolder.py
+++ b/PythonFiles/Data/DataHolder.py
@@ -17,8 +17,8 @@ class DataHolder():
         self.gui_cfg = gui_cfg
 
         # Object that sends information to the database
-        #self.data_sender = DBSender(gui_cfg)
-        self.dbclient = DBSendClient()
+        self.data_sender = DBSender(gui_cfg)
+        #self.dbclient = DBSendClient()
         
         self.data_dict = {
                 'user_ID': "_",
@@ -66,9 +66,9 @@ class DataHolder():
         print("\n\n\n\n\n\nIs the user new?:{}\n\n\n\n\n\n".format(is_new_user_ID))
 
         if is_new_user_ID:
-            #self.data_sender.add_new_user_ID(self.data_dict['user_ID'], passwd)        
-            message = "add_new_user_ID;{'user_ID': {}, 'passwd': {}}".format(self.data_dict['user_ID'], passwd)
-            self.dbclient.send_request(message)
+            self.data_sender.add_new_user_ID(self.data_dict['user_ID'], passwd)        
+            #message = "add_new_user_ID;{'user_ID': {}, 'passwd': {}}".format(self.data_dict['user_ID'], passwd)
+            #self.dbclient.send_request(message)
 
 
 
@@ -78,9 +78,9 @@ class DataHolder():
         self.data_dict['is_new_board'] = self.test_new_board(self.get_serial_ID())        
         print("result received:", self.data_dict['is_new_board'])
         if self.data_dict['is_new_board'] == False:
-            #prev_results = self.data_sender.get_previous_test_results(self.get_serial_ID())
-            message = "get_previous_test_results;{'serial_number': {}}".format(self.get_serial_ID())
-            prev_results = self.dbclient.send_request(message)
+            prev_results = self.data_sender.get_previous_test_results(self.get_serial_ID())
+            #message = "get_previous_test_results;{'serial_number': {}}".format(self.get_serial_ID())
+            #prev_results = self.dbclient.send_request(message)
             for result in prev_results:
                 test_id = result[0]
                 pass_fail = result[1]
@@ -111,9 +111,9 @@ class DataHolder():
     ##################################################
 
     def set_serial_ID(self, sn):
-        #self.data_sender.add_new_board(sn)
-        message = "add_new_board;{'sn': {}}".format(sn)
-        self.dbclient.send_request(message)
+        self.data_sender.add_new_board(sn)
+        #message = "add_new_board;{'sn': {}}".format(sn)
+        #self.dbclient.send_request(message)
                     
         self.data_dict['current_serial_ID'] = sn
         logging.info("DataHolder: Serial Number has been set.")
@@ -122,9 +122,9 @@ class DataHolder():
 
     def test_new_board(self, sn):
         logging.info("DataHolder: Checking if serial is a new board")
-        #return self.data_sender.is_new_board(sn)
-        message = "is_new_board;{'sn': {}}".format(sn)
-        return self.dbclient.send_request(message)
+        return self.data_sender.is_new_board(sn)
+        #message = "is_new_board;{'sn': {}}".format(sn)
+        #return self.dbclient.send_request(message)
 
 
 
@@ -178,16 +178,16 @@ class DataHolder():
         with open("{}/JSONFiles/storage.json".format(PythonFiles.__path__[0]), "w") as outfile:
             print(info_dict)
             json.dump(info_dict, outfile)
-        #self.data_sender.add_test_json("{}/JSONFiles/storage.json".format(PythonFiles.__path__[0]), file_path_list[index])
-        message = "add_test_json;{'json_file': {}, 'datafile_name': {}}".format("{}/JSONFiles/storage.json".format(PythonFiles.__path__[0]), file_path_list[index])
-        self.dbclient.send_request(message)
+        self.data_sender.add_test_json("{}/JSONFiles/storage.json".format(PythonFiles.__path__[0]), file_path_list[index])
+        #message = "add_test_json;{'json_file': {}, 'datafile_name': {}}".format("{}/JSONFiles/storage.json".format(PythonFiles.__path__[0]), file_path_list[index])
+        #self.dbclient.send_request(message)
         logging.info("DataHolder: Test results sent to database.")
 
     #################################################
    
     def get_all_users(self):
-        #users_list = self.data_sender.get_usernames() 
-        users_list = self.dbclient.send_request("get_usernames")
+        users_list = self.data_sender.get_usernames() 
+        #users_list = self.dbclient.send_request("get_usernames")
         #print ("\n users_list:", users_list)
         return users_list
 


### PR DESCRIPTION
…atabase

Now that the cmslab3 web server is reachable from cmsfactorynet, we don't need to do anything fancy for grabbing information to populate the GUI. 
- Removing references to the dbclient when making calls for DB info
- Adding http request calls in their place