### PR TITLE
Fixing logging directory

### DIFF
--- a/PythonFiles/utils/helper.py
+++ b/PythonFiles/utils/helper.py
@@ -1,11 +1,12 @@
 # Helper functions for smooth operation
 
 from pathlib import Path
+import os
 
 def get_install_path():
 
     return Path(__file__).parent.parent.parent
 
 def get_logging_path():
-    return get_install_path().parent / "GUILogs/gui.log"
+    return os.getenv("HOME") + "/shared/"
 


### PR DESCRIPTION
Log files should be written to the shared directory as it is always in the same place:
- Modified `get_logging_path` function in `helper.py` to use absolute file paths