### PR TITLE
Fixing bug causing mismatch of test index and data from test

### DIFF
--- a/PythonFiles/Data/DBSender.py
+++ b/PythonFiles/Data/DBSender.py
@@ -244,6 +244,7 @@ class DBSender():
 
         if (self.use_database):
             r = requests.post('{}/add_test_json.py'.format(self.db_url), data = results, files = attach_data)
+            print(r.text)
         else:
             pass
 

--- a/PythonFiles/Data/DBSender.py
+++ b/PythonFiles/Data/DBSender.py
@@ -244,7 +244,6 @@ class DBSender():
 
         if (self.use_database):
             r = requests.post('{}/add_test_json.py'.format(self.db_url), data = results, files = attach_data)
-            print(r.text)
         else:
             pass
 

--- a/PythonFiles/GUIWindow.py
+++ b/PythonFiles/GUIWindow.py
@@ -57,7 +57,7 @@ class GUIWindow():
         self.current_test_index = 0
         self.gui_cfg = GUIConfig(board_cfg)
         self.main_path = main_path
-                             
+
         # Create the window named "self.master_window"
         self.master_window = tk.Tk()
         self.master_window.title("HGCAL Test Window")
@@ -205,10 +205,11 @@ class GUIWindow():
     #################################################
 
 
-    def run_all_tests(self, test_idx):
+    def run_all_tests(self):
         logging.info("Run all tests method has been selected.")
-        self.running_all_idx = test_idx
-        self.current_test_index = test_idx
+        self.running_all_idx = 0
+        self.current_test_index = 0
+        self.data_holder.setTestIdx(self.current_test_index)
         self.run_all_tests_bool = True
 
         test_client = REQClient(self.gui_cfg, 'test{}'.format(self.running_all_idx), self.data_holder.data_dict['current_full_ID'], self.data_holder.data_dict['user_ID'], self.conn_trigger)
@@ -301,6 +302,7 @@ class GUIWindow():
 
     def set_frame_login_frame(self):  
 
+        self.sidebar.clean_up_btns()
         self.sidebar.update_sidebar(self)
         self.login_frame.update_frame(self)
         self.set_frame(self.login_frame)        
@@ -378,10 +380,11 @@ class GUIWindow():
     #################################################
 
     def set_frame_test_in_progress(self, queue):
+        self.test_in_progress_frame.remove_stop_txt()
         self.set_frame(self.test_in_progress_frame)
         
         logging.debug("GUIWindow: The frame has been set to test_in_progress_frame.")
-        #self.sidebar.disable_all_btns()
+        self.sidebar.disable_all_btns()
         passed = self.test_in_progress_frame.begin_update(self.master_window, queue, self)
         self.go_to_next_test()   
 
@@ -402,6 +405,7 @@ class GUIWindow():
     def go_to_next_test(self):
             
         # Updates the sidebar every time the frame is set
+        self.sidebar.clean_up_btns()
         self.sidebar.update_sidebar(self)
 
         total_num_tests = self.data_holder.total_test_num
@@ -454,6 +458,7 @@ class GUIWindow():
  
 
         # Updates the sidebar every time the frame is set
+        self.sidebar.clean_up_btns()
         self.sidebar.update_sidebar(self)
 
         # If frame is test_in_progress frame, disable the close program button
@@ -805,6 +810,10 @@ class GUIWindow():
 
     #################################################
 
+    # Function for stopping tests gracefully
+    def stop_tests(self):
+        #self.sidebar.disable_all_btns()
+        self.run_all_tests_bool = False
 
     # Called when the yes button is pressed to destroy both windows
     def destroy_function(self):

--- a/PythonFiles/Scenes/SidebarScene.py
+++ b/PythonFiles/Scenes/SidebarScene.py
@@ -93,8 +93,13 @@ class SidebarScene(ttk.Frame):
         self.s.theme_use('awdark')
 
     #################################################
+
+    def clean_up_btns(self):
+        for btn in self.all_btns:
+            btn.destroy()
+
     def update_sidebar(self, _parent):
-        
+       
         logger.info("SidebarScene: The sidebar has been updated.")
 
                 # Variables for easy button editing
@@ -174,8 +179,7 @@ class SidebarScene(ttk.Frame):
             )
         self.btn_summary.grid(column = 0, row = 4 + self.data_holder.getNumTest(), pady = btn_pady)
 
-        
-        self.report_btn = ttk.Button(
+        self.restart_server_btn = ttk.Button(
             self.viewingFrame, 
             #pady = btn_pady,
             text = 'Restart Server',
@@ -184,9 +188,9 @@ class SidebarScene(ttk.Frame):
             #font = ('Kozuka Gothic Pr6N L', 8),
             command = lambda: self.restart_server(_parent)
             )
-        self.report_btn.grid(column = 0, row = 5 + self.data_holder.getNumTest(), pady = btn_pady)
+        self.restart_server_btn.grid(column = 0, row = 5 + self.data_holder.getNumTest(), pady = btn_pady)
         
-        self.report_btn = ttk.Button(
+        self.reload_firmware_btn = ttk.Button(
             self.viewingFrame, 
             #pady = btn_pady,
             text = 'Reload Firmware',
@@ -195,9 +199,9 @@ class SidebarScene(ttk.Frame):
             #font = ('Kozuka Gothic Pr6N L', 8),
             command = lambda: self.reload_firmware(_parent)
             )
-        self.report_btn.grid(column = 0, row = 6 + self.data_holder.getNumTest(), pady = (btn_pady))
+        self.reload_firmware_btn.grid(column = 0, row = 6 + self.data_holder.getNumTest(), pady = (btn_pady))
         
-        self.report_btn = ttk.Button(
+        self.reset_power_btn = ttk.Button(
             self.viewingFrame, 
             #pady = btn_pady,
             text = 'Reset Power',
@@ -206,9 +210,9 @@ class SidebarScene(ttk.Frame):
             #font = ('Kozuka Gothic Pr6N L', 8),
             command = lambda: self.reset_power(_parent)
             )
-        self.report_btn.grid(column = 0, row = 7 + self.data_holder.getNumTest(), pady = (btn_pady, 235))
+        self.reset_power_btn.grid(column = 0, row = 7 + self.data_holder.getNumTest(), pady = (btn_pady, 235))
 
-
+        self.all_btns = [*self.test_btns, self.btn_summary, self.restart_server_btn, self.reload_firmware_btn, self.reset_power_btn]
 
         # List for creating check marks with for loop
         self.list_of_pass_fail = self.data_holder.data_lists['test_results']
@@ -301,11 +305,13 @@ class SidebarScene(ttk.Frame):
     #################################################
 
     def disable_all_btns(self):
-        self.btn_login.config(state = 'disabled')
-        self.btn_scan.config(state = 'disabled')
-        for btn in self.test_btns:
+        for btn in self.all_btns:
             btn.config(state = 'disabled')
-        self.btn_summary.config(state = 'disabled')
+        #self.btn_login.config(state = 'disabled')
+        #self.btn_scan.config(state = 'disabled')
+        #for btn in self.test_btns:
+        #    btn.config(state = 'disabled')
+        #self.btn_summary.config(state = 'disabled')
 
     #################################################
 

--- a/PythonFiles/Scenes/TestInProgressScene.py
+++ b/PythonFiles/Scenes/TestInProgressScene.py
@@ -42,13 +42,13 @@ class TestInProgressScene(ttk.Frame):
     ##################################################
 
     # A function for the stop button
-    def btn_stop_action(self, _parent):
-        self.window_closed = True
-        _parent.go_to_next_test()
+    #def btn_stop_action(self, _parent):
+    #    self.window_closed = True
+    #    _parent.go_to_next_test()
 
-        
-        # Destroys the console window
-        self.console_destroy()
+    #    
+    #    # Destroys the console window
+    #    self.console_destroy()
         
     #################################################    
 
@@ -103,6 +103,11 @@ class TestInProgressScene(ttk.Frame):
             orient = 'horizontal',
             mode = 'indeterminate', length = 350)
         self.progressbar.pack(padx = 50)
+        self.stop_txt = ttk.Label(self,
+            text='Waiting for test to finish...',
+            font=('Arial', 15)
+        )
+        self.stop_txt.pack_forget()
         # A Button To Stop the Progress Bar and Progress Forward (Temporary until we link to actual progress)
         btn_stop = ttk.Button(
             self, 
@@ -119,10 +124,14 @@ class TestInProgressScene(ttk.Frame):
 
     # A function for the stop button
     def btn_stop_action(self, _parent):
-        _parent.return_to_current_test()
+        #_parent.return_to_current_test()
         self.progressbar.stop()
+        self.stop_txt.pack(padx=0, pady=50)
+        _parent.stop_tests()
         #self.queue.put('Stop')
 
+    def remove_stop_txt(self):
+        self.stop_txt.pack_forget()
 
     # Goes to the next scene after the progress scene is complete
     def go_to_next_frame(self, _parent):
@@ -189,7 +198,6 @@ class TestInProgressScene(ttk.Frame):
                     if "Results received successfully." in text:
                     
                         message =  self.conn.recv()
-                        print(message)   
                         self.data_holder.update_from_json_string(message) 
                         
                         logger.info("TestInProgressScene: JSON Received.")

--- a/PythonFiles/Scenes/TestScene.py
+++ b/PythonFiles/Scenes/TestScene.py
@@ -160,15 +160,15 @@ class TestScene(ttk.Frame):
             )
         btn_confirm.pack(anchor = 'center', pady = 5)
 
-        if (self.test_idx == 0):
+        #if (self.test_idx == 0):
 
-            # Create a button for confirming test
-            run_all_btn = ttk.Button(
-                frm_logout, 
-                text = "Run All Tests",
-                command = lambda:self.run_all_action(parent),
-                )
-            run_all_btn.pack(anchor = 'center', pady = 5)
+        # Create a button for confirming test
+        run_all_btn = ttk.Button(
+            frm_logout, 
+            text = "Run All Tests",
+            command = lambda:self.run_all_action(parent),
+            )
+        run_all_btn.pack(anchor = 'center', pady = 5)
 
 
         # Create a rescan button
@@ -200,7 +200,7 @@ class TestScene(ttk.Frame):
 
     def run_all_action(self, _parent):
        
-        _parent.run_all_tests(self.test_idx) 
+        _parent.run_all_tests() 
         
 
     #################################################


### PR DESCRIPTION
Test index error could occur with the following sequence of events:
- Run all tests
- Hit the stop button during a test run
- Changing test scene using the sidebar before the previous test finished.

Users are now unable to switch from the current test in progress scene to another test scene while a test is running. Additionally, the stop button prompts the user to wait for the current test to finish before taking them out of the run all test loop.

Additionally, the run all test button is now available on all test scenes, not just the first test scene. This button has the same functionality on all scenes: 
- Reset the current test index to 0
- Run all tests sequentially
- End once finished with all tests

In the future, we may think about changing this button to run all tests that haven't been run rather than all, but this would more than likely cause mismatched test idx and results again. 