### PR TITLE
Fix results upload to reduce possiblitly of test_id/result mismatch

### DIFF
--- a/PythonFiles/Data/DBSender.py
+++ b/PythonFiles/Data/DBSender.py
@@ -2,6 +2,7 @@ import requests
 import json
 import socket
 import logging
+from pathlib import Path
 # from read_barcode import read_barcode
 
 # python scripts run from here are on the machine that contains the server and database
@@ -232,10 +233,20 @@ class DBSender():
             return lines[i]
         
 
-    def add_test_json(self, json_file, datafile_name):
-        load_file = open(json_file)
-        results = json.load(load_file)        
-        load_file.close()
+    def add_test_json(self, json_file):
+        
+        with open(json_file) as load_file:
+            results = json.load(load_file)        
+
+        test_attach = results.pop('data', None)
+        datafile_name = "{}/JSONFiles/sending.json".format(str(Path.home().absolute()))
+
+        results['test_type'] = results['name']
+        results['full_id'] = results['board_sn']
+        results['successful'] = int(results['pass'])
+
+        with open(datafile_name, 'w') as datafile:
+            json.dump(test_attach, datafile)
 
         datafile = open(datafile_name, "rb")        
 
@@ -244,8 +255,24 @@ class DBSender():
 
         if (self.use_database):
             r = requests.post('{}/add_test_json.py'.format(self.db_url), data = results, files = attach_data)
+            print(r.text)
         else:
             pass
+
+    #def add_test_json(self, json_file, datafile_name):
+    #    load_file = open(json_file)
+    #    results = json.load(load_file)        
+    #    load_file.close()
+
+    #    datafile = open(datafile_name, "rb")        
+
+    #    attach_data = {'attach1': datafile}
+    #    #print("Read from json file:", results)
+
+    #    if (self.use_database):
+    #        r = requests.post('{}/add_test_json.py'.format(self.db_url), data = results, files = attach_data)
+    #    else:
+    #        pass
 
  # Returns a list of all different types of tests
     def get_test_list(self):

--- a/PythonFiles/Data/DataHolder.py
+++ b/PythonFiles/Data/DataHolder.py
@@ -320,16 +320,17 @@ class DataHolder():
             temp = 1 
 
 
-        if self.config_id:
-            info_dict = {"full_id":self.get_full_ID(),"tester": self.data_dict['user_ID'], "test_type": self.index_gui_to_db[self.data_dict['tests_run'][index]], "successful": temp, "comments": self.data_dict['comments'], 'config':self.config_id}
-        else:
-            info_dict = {"full_id":self.get_full_ID(),"tester": self.data_dict['user_ID'], "test_type": self.index_gui_to_db[self.data_dict['tests_run'][index]], "successful": temp, "comments": self.data_dict['comments']}
+        #if self.config_id:
+        #    info_dict = {"full_id":self.get_full_ID(),"tester": self.data_dict['user_ID'], "test_type": self.index_gui_to_db[self.data_dict['tests_run'][index]], "successful": temp, "comments": self.data_dict['comments'], 'config':self.config_id}
+        #else:
+        #    info_dict = {"full_id":self.get_full_ID(),"tester": self.data_dict['user_ID'], "test_type": self.index_gui_to_db[self.data_dict['tests_run'][index]], "successful": temp, "comments": self.data_dict['comments']}
         
-        with open("{}/JSONFiles/storage.json".format(str(Path.home().absolute())), "w") as outfile:
-            print(str(info_dict) + '\r\n')
-            json.dump(info_dict, outfile)
+        #with open("{}/JSONFiles/storage.json".format(str(Path.home().absolute())), "w") as outfile:
+        #    print(str(info_dict) + '\r\n')
+        #    json.dump(info_dict, outfile)
 
-        self.data_sender.add_test_json("{}/JSONFiles/storage.json".format(str(Path.home().absolute())), file_path_list[index])
+        #self.data_sender.add_test_json("{}/JSONFiles/storage.json".format(str(Path.home().absolute())), file_path_list[index])
+        self.data_sender.add_test_json(file_path_list[index])
         logger.info("DataHolder: Test results sent to database.")
 
         self.data_dict['comments'] = '_'
@@ -362,7 +363,7 @@ class DataHolder():
         test_type = test_names[self.current_test_idx]
 
         with open("{}/JSONFiles/Current_{}_JSON.json".format(str(Path.home().absolute()), test_names[self.current_test_idx].replace(" ", "").replace("/", "")), "w") as file:
-            json.dump(json_dict['data'], file)
+            json.dump(json_dict, file)
         self.data_dict['test{}_completed'.format(self.current_test_idx)] = True
         self.data_dict['test{}_pass'.format(self.current_test_idx)] = json_dict["pass"]
         comments = json_dict.get('comments', '_')


### PR DESCRIPTION
Previous versions would split test results into a different file from test metadata. This could cause test results to be uploaded for a non-matching test index. 

The test data needs to be split into a separate file on the machine running the GUI in order to conform with database upload. This process is now handled in a single function, and pulls information from a single file which contains both test data and metadata. 

This should hopefully fix the issue of wrong data associated with a test